### PR TITLE
Enable Dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,24 @@
+name: Dependabot Auto Merge
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  enable-automerge:
+    if: >
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      startsWith(github.event.pull_request.head.ref, 'dependabot/') &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.7
 
 FROM node:24-alpine AS base
+ENV NPM_CONFIG_ENGINE_STRICT=true
 RUN apk add --no-cache tini
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

- enable squash auto-merge for same-repository Dependabot PRs after branch-protection checks pass
- enforce the declared Node engine range during Docker builds

## Why

This matches the F5 Dependabot workflow while ensuring a Docker base-image update cannot bypass the project's Node 22/24 support policy with only an npm engine warning.

## Validation

- workflow YAML parsed successfully
- `npm run lint`
- `npm test`
- `npm audit --audit-level=high`
- `helm lint chart`
- `docker compose config --quiet`
- Docker test target build