### PR TITLE
Publish Helm chart to GHCR

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,15 +19,15 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
       - name: Log in to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
@@ -36,7 +36,7 @@ jobs:
         run: echo "version=$(jq -r .version package.json)" >> "$GITHUB_OUTPUT"
       - name: Generate image metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: jonfairbanks/docker-node-app
           tags: |
@@ -45,7 +45,7 @@ jobs:
             type=raw,value=latest,enable=${{ github.event.workflow_run.head_branch == 'master' }}
             type=raw,value=${{ steps.package.outputs.version }},enable=${{ github.event.workflow_run.head_branch == 'master' }}
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           target: production
@@ -60,27 +60,32 @@ jobs:
     name: Publish Helm chart
     if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'master'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
-      - uses: azure/setup-helm@v5
-      - name: Check out chart repository
-        uses: actions/checkout@v7
+          fetch-depth: 2
+      - name: Set up Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
         with:
-          repository: jonfairbanks/helm-charts
-          token: ${{ secrets.HELM_CHARTS_PAT }}
-          path: helm-charts
-      - name: Package chart
-        run: helm package chart --destination helm-charts/_releases
-      - name: Publish chart package
-        working-directory: helm-charts
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add _releases
-          git diff --cached --quiet && exit 0
-          git commit -m "Publish docker-node-app chart ${SOURCE_SHA::7}"
-          git push
+          version: v4.2.3
+      - name: Publish chart to GHCR
         env:
-          SOURCE_SHA: ${{ github.event.workflow_run.head_sha }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          version=$(awk '/^version:/ { print $2; exit }' chart/Chart.yaml)
+          chart=oci://ghcr.io/jonfairbanks/charts/docker-node-app
+          if helm show chart "$chart" --version "$version" >/dev/null 2>&1; then
+            if git diff --quiet HEAD^ HEAD -- chart; then
+              echo "${chart}:${version} already exists and this change does not modify the chart."
+              exit 0
+            fi
+            echo "${chart}:${version} already exists; increment chart/Chart.yaml." >&2
+            exit 1
+          fi
+          echo "$GHCR_TOKEN" | helm registry login ghcr.io --username "$GITHUB_ACTOR" --password-stdin
+          helm package chart --destination /tmp/charts
+          helm push "/tmp/charts/docker-node-app-${version}.tgz" oci://ghcr.io/jonfairbanks/charts


### PR DESCRIPTION
## Summary
- publish docker-node-app as an OCI Helm chart in GHCR
- remove cross-repository package commits and PAT usage
- pin every action in the publish workflow to a verified commit SHA

## Validation
- helm lint --strict chart
- helm package chart
- actionlint .github/workflows/publish.yaml