### PR TITLE
Fix Helm chart non-root runtime

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -16,7 +16,7 @@ kubeVersion: ">=1.25.0-0"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.0.0
+version: 3.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -20,6 +20,8 @@ podLabels: {}
 
 podSecurityContext:
   runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
   seccompProfile:
     type: RuntimeDefault
 


### PR DESCRIPTION
## Summary
- set the numeric UID/GID for the Node runtime user
- bump the chart to 3.0.1

## Root cause
Kubernetes rejected 3.0.0 because runAsNonRoot was enabled while the image declared the named user node; kubelet could not verify that the name was non-root.

## Validation
- confirmed the image runs as UID/GID 1000
- helm lint --strict chart
- kubeconform against Kubernetes 1.36.2
- installed in a kind Kubernetes 1.36.1 cluster
- deployment reached 3/3 Ready
- helm test succeeded through the ClusterIP Service