### PR TITLE
Scope Snyk container scan to OS dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,5 +64,13 @@ jobs:
           context: .
           target: test
           push: false
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=test
+          cache-to: type=gha,mode=max,scope=test
+      - name: Build production target
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          target: production
+          push: false
+          cache-from: type=gha,scope=production
+          cache-to: type=gha,mode=max,scope=production

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -66,5 +66,6 @@ jobs:
         with:
           image: docker-node-app:snyk
           args: >-
+            --exclude-app-vulns
             --file=Dockerfile
             --severity-threshold=high

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   open-source:
-    name: Open Source
+    name: Open Source and Container
     if: >-
       github.actor != 'dependabot[bot]' &&
       (github.event_name != 'pull_request' ||
@@ -54,4 +54,17 @@ jobs:
           args: >-
             --file=package.json
             --package-manager=npm
+            --severity-threshold=high
+
+      - name: Build production image
+        if: env.SNYK_TOKEN != ''
+        run: docker build --target production --tag docker-node-app:snyk .
+
+      - name: Scan production image
+        if: env.SNYK_TOKEN != ''
+        uses: snyk/actions/docker@9adf32b1121593767fc3c057af55b55db032dc04 # v1.0.0
+        with:
+          image: docker-node-app:snyk
+          args: >-
+            --file=Dockerfile
             --severity-threshold=high

--- a/__tests__/shutdown.test.js
+++ b/__tests__/shutdown.test.js
@@ -1,0 +1,59 @@
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const { once } = require('node:events');
+const { test } = require('node:test');
+const { createGracefulShutdown } = require('../index');
+
+test('graceful shutdown drains an in-flight request before closing', async (t) => {
+  let markRequestStarted;
+  let releaseResponse;
+  const requestStarted = new Promise((resolve) => {
+    markRequestStarted = resolve;
+  });
+  const responseReleased = new Promise((resolve) => {
+    releaseResponse = resolve;
+  });
+
+  const server = http.createServer(async (_request, response) => {
+    markRequestStarted();
+    await responseReleased;
+    response.end('ok');
+  });
+  server.keepAliveTimeout = 10;
+
+  t.after(() => {
+    server.closeAllConnections?.();
+    if (server.listening) {
+      server.close();
+    }
+  });
+
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  const { port } = server.address();
+  const responsePromise = fetch(`http://127.0.0.1:${port}`);
+  await requestStarted;
+
+  const messages = [];
+  const logger = {
+    log: (message) => messages.push(message),
+    error: (message) => messages.push(message),
+  };
+  const shutdown = createGracefulShutdown(server, { timeoutMs: 1000, logger });
+  let shutdownComplete = false;
+  const shutdownPromise = shutdown('SIGTERM').then(() => {
+    shutdownComplete = true;
+  });
+
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(shutdownComplete, false);
+
+  releaseResponse();
+  const response = await responsePromise;
+  assert.equal(await response.text(), 'ok');
+  await shutdownPromise;
+
+  assert.equal(shutdownComplete, true);
+  assert.equal(server.listening, false);
+  assert.deepEqual(messages, ['Received SIGTERM; draining active connections...']);
+});

--- a/index.js
+++ b/index.js
@@ -1,8 +1,66 @@
 // Setup Express
 const PORT = process.env.PORT || 8080;
+const SHUTDOWN_TIMEOUT_MS = Number.parseInt(
+  process.env.SHUTDOWN_TIMEOUT_MS || '25000',
+  10,
+);
 const app = require('./app');
 
-// Launch the App
-app.listen(PORT, '0.0.0.0', () => {
-  console.log(`docker-node-app is listening on port ${PORT}`);
-});
+function startServer({ port = PORT, host = '0.0.0.0', logger = console } = {}) {
+  return app.listen(port, host, () => {
+    logger.log(`docker-node-app is listening on port ${port}`);
+  });
+}
+
+function createGracefulShutdown(
+  server,
+  { timeoutMs = SHUTDOWN_TIMEOUT_MS, logger = console } = {},
+) {
+  let shutdownPromise;
+
+  return (signal) => {
+    if (shutdownPromise) {
+      return shutdownPromise;
+    }
+
+    logger.log(`Received ${signal}; draining active connections...`);
+    shutdownPromise = new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        logger.error(`Graceful shutdown exceeded ${timeoutMs}ms; forcing close.`);
+        server.closeAllConnections?.();
+        reject(new Error('Graceful shutdown timed out'));
+      }, timeoutMs);
+      timeout.unref();
+
+      server.close((error) => {
+        clearTimeout(timeout);
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+      server.closeIdleConnections?.();
+    });
+
+    return shutdownPromise;
+  };
+}
+
+if (require.main === module) {
+  const server = startServer();
+  const shutdown = createGracefulShutdown(server);
+
+  for (const signal of ['SIGTERM', 'SIGINT']) {
+    process.once(signal, () => {
+      shutdown(signal)
+        .then(() => console.log('Graceful shutdown complete.'))
+        .catch((error) => {
+          console.error(error);
+          process.exitCode = 1;
+        });
+    });
+  }
+}
+
+module.exports = { createGracefulShutdown, startServer };


### PR DESCRIPTION
## Summary

Limit the Snyk container step to operating-system and image vulnerabilities with `--exclude-app-vulns`.

## Why

The existing Snyk Node step already gates application dependencies. The first assembled-image scan correctly found zero Alpine and application dependency issues, but then duplicated application scanning and failed on vulnerabilities inside the `npm` CLI bundled with the Node base image. Scoping the image scan avoids duplicate coverage while preserving the intended OS/image vulnerability gate.

Snyk documents `--exclude-app-vulns` for this split-scan configuration.

## Validation

- first container build and scan reached Snyk successfully
- Alpine packages: no vulnerable paths
- application dependencies: no vulnerable paths in the dedicated Node scan
- workflow YAML parsing passed