### PR TITLE
Scope Snyk container scan to OS dependencies

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -66,5 +66,6 @@ jobs:
         with:
           image: docker-node-app:snyk
           args: >-
+            --exclude-app-vulns
             --file=Dockerfile
             --severity-threshold=high


### PR DESCRIPTION
## Summary

Limit the Snyk container step to operating-system and image vulnerabilities with `--exclude-app-vulns`.

## Why

The existing Snyk Node step already gates application dependencies. The first assembled-image scan correctly found zero Alpine and application dependency issues, but then duplicated application scanning and failed on vulnerabilities inside the `npm` CLI bundled with the Node base image. Scoping the image scan avoids duplicate coverage while preserving the intended OS/image vulnerability gate.

## Validation

- first container build and scan reached Snyk successfully
- Alpine packages: no vulnerable paths
- application dependencies: no vulnerable paths in the dedicated Node scan
- workflow YAML parsing passed